### PR TITLE
HRK is replaced by EUR after 1 Jan, 2023

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -1256,7 +1256,7 @@ export default [
     alpha2: 'HR',
     alpha3: 'HRV',
     countryCallingCodes: ['+385'],
-    currencies: ['HRK'],
+    currencies: ['EUR'],
     emoji: '🇭🇷',
     ioc: 'CRO',
     languages: ['hrv'],


### PR DESCRIPTION
https://www.loc.gov/item/global-legal-monitor/2022-07-31/croatia-euro-to-be-introduced-as-official-currency

```
On July 12, 2022, the Council of the European Union adopted legislation that will enable Croatia to begin replacing its national currency, the kuna (HRK), with the euro (€) on January 1, 2023, and become the 20th member of the euro area.
```