### PR TITLE
Add Maori to New Zealand

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -2133,7 +2133,7 @@ export default [
     currencies: ['NZD'],
     emoji: '🇳🇿',
     ioc: 'NZL',
-    languages: ['eng'],
+    languages: ['eng', 'mri'],
     name: 'New Zealand',
     status: 'assigned',
   },


### PR DESCRIPTION
Maori is an official language of New Zealand
[https://en.wikipedia.org/wiki/New_Zealand](https://en.wikipedia.org/wiki/New_Zealand)