### PR TITLE
Singapore IOC code switched to SGP after 2016

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -2469,7 +2469,7 @@ export default [
     countryCallingCodes: ['+65'],
     currencies: ['SGD'],
     emoji: '🇸🇬',
-    ioc: 'SIN',
+    ioc: 'SGP',
     languages: ['eng', 'zho', 'msa', 'tam'],
     name: 'Singapore',
     status: 'assigned',


### PR DESCRIPTION
https://en.wikipedia.org/wiki/List_of_IOC_country_codes