### PR TITLE
Update names of North Macedonia and Eswatini

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -1807,7 +1807,7 @@ export default [
     emoji: '🇲🇰',
     ioc: 'MKD',
     languages: ['mkd'],
-    name: 'Macedonia, The Former Yugoslav Republic Of',
+    name: 'North Macedonia',
     status: 'assigned',
   },
   {
@@ -2657,7 +2657,7 @@ export default [
     emoji: '🇸🇿',
     ioc: 'SWZ',
     languages: ['eng', 'ssw'],
-    name: 'Swaziland',
+    name: 'Eswatini',
     status: 'assigned',
   },
   {


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Eswatini since 2018
https://en.wikipedia.org/wiki/North_Macedonia since 2019
