### PR TITLE
Correct the Lithuanian litas ISO code

### DIFF
--- a/src/data/currencies.js
+++ b/src/data/currencies.js
@@ -522,7 +522,7 @@ export default [
     number: '426',
   },
   {
-    code: 'EUR',
+    code: 'LTL',
     decimals: 2,
     name: 'Lithuanian litas',
     number: '440',


### PR DESCRIPTION
### Issue
I noticed that EUR shows up twice in my filters. Upon checking the library's code, I found that the now obsolete currency of Lithuanian litas has a wrong code assigned to it (as `EUR` instead of `LTL`).

_Source: I am Lithuanian, but also the currency [changed to EUR on 2015](https://en.wikipedia.org/wiki/Lithuania_and_the_euro)_

### What was done
- [x] Changed Lithuanian litas' code to `LTL`