### PR TITLE
Add STN for São Tomé and Príncipe dobra currency

### DIFF
--- a/src/data/currencies.js
+++ b/src/data/currencies.js
@@ -816,6 +816,12 @@ export default [
     number: '678',
   },
   {
+    code: 'STN',
+    decimals: 2,
+    name: 'São Tomé and Príncipe dobra',
+    number: '930',
+  },
+  {
     code: 'SYP',
     decimals: 2,
     name: 'Syrian pound',


### PR DESCRIPTION
On 1 January 2018 São Tomé and Príncipe dobra (STD) was given the new ISO 4217 currency code STN.

https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_164.pdf

https://en.wikipedia.org/wiki/ISO_4217
