### PR TITLE
Change currency code from STD to STN for São Tomé and Príncipe

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -2598,7 +2598,7 @@ export default [
     alpha2: 'ST',
     alpha3: 'STP',
     countryCallingCodes: ['+239'],
-    currencies: ['STD'],
+    currencies: ['STN'],
     emoji: '🇸🇹',
     ioc: 'STP',
     languages: ['por'],


### PR DESCRIPTION
Sorry I should change the currency code for Sao Tome and Principe in countries.js.

On 1 January 2018 São Tomé and Príncipe dobra (STD) was given the new ISO 4217 currency code STN.

https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_164.pdf

https://en.wikipedia.org/wiki/ISO_4217
